### PR TITLE
ログイン後のヘッダーの言語表記のレスポンシブデザイン修正 

### DIFF
--- a/src/components/layouts/LoggedInHeader.jsx
+++ b/src/components/layouts/LoggedInHeader.jsx
@@ -151,13 +151,11 @@ export const LoggedInHeader = () => {
           ) : (
             <Typography sx={{ ml: 'auto' }}>
               <Button
-                sx={{ fontSize: '3px'}}
                 onClick={() => changeLanguage('ja')}
               >
                 日本語
               </Button>
               <Button
-                sx={{ fontSize: '3px' }}
                 onClick={() => changeLanguage('en')}
               >
                 English


### PR DESCRIPTION
・スマホでのログイン後のヘッダーの言語表記の大きさを修正 